### PR TITLE
Add Python OCR service with Tesseract and Paddle pipelines

### DIFF
--- a/python_service/.gitignore
+++ b/python_service/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+python_service_data/

--- a/python_service/Dockerfile
+++ b/python_service/Dockerfile
@@ -1,0 +1,26 @@
+FROM python:3.10-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        tesseract-ocr \
+        tesseract-ocr-vie \
+        poppler-utils \
+        libreoffice \
+        fonts-dejavu \
+        wget \
+        ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY requirements.txt /app/requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . /app
+
+EXPOSE 8000
+
+CMD ["uvicorn", "python_service.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/python_service/README.md
+++ b/python_service/README.md
@@ -1,0 +1,86 @@
+# Python OCR Service
+
+Dịch vụ OCR chạy bằng Python phục vụ nghiên cứu hệ thống quản lý khoản vay. Service hỗ trợ hai chế độ OCR:
+
+- **FAST (Tesseract)**: nhanh, phù hợp tài liệu rõ nét.
+- **ENHANCED (PaddleOCR)**: chính xác hơn cho tài liệu scan khó.
+
+Kết quả OCR, ảnh trung gian và lịch sử xử lý được lưu trong SQLite.
+
+## Tính năng chính
+
+- Nhận diện nhiều định dạng tài liệu: ảnh (PNG/JPEG/TIFF/WEBP), PDF (scan/text) và Word (DOC/DOCX).
+- Tự động chuyển DOC/DOCX sang PDF bằng LibreOffice headless, sau đó render ảnh độ phân giải 300 DPI để OCR.
+- Chuỗi tiền xử lý ảnh tối ưu cho OCR: grayscale → khử nhiễu (fastNlMeans) → CLAHE → sharpen → adaptive threshold.
+- Lưu lại ảnh gốc, ảnh trang và ảnh sau tiền xử lý cho từng lần chạy.
+- Thực thi đồng thời hai engine (Tesseract & PaddleOCR) ở chế độ `auto`, chọn kết quả có độ tin cậy trung bình cao nhất.
+- REST API (FastAPI) để upload tài liệu, lấy kết quả, và tra cứu lịch sử.
+- Lưu lịch sử, ảnh và kết quả vào SQLite (`python_service_data/ocr_history.sqlite`).
+
+## Cấu trúc
+
+```
+python_service/
+  main.py                # FastAPI entry point
+  requirements.txt
+  ocr_service/
+    config.py            # Đọc biến môi trường & cấu hình
+    database.py          # SQLAlchemy ORM + session helper
+    storage.py           # Quản lý thư mục lưu trữ
+    preprocess.py        # Tiền xử lý ảnh với OpenCV
+    document_processor.py# Chuyển đổi định dạng, tách trang
+    engines.py           # Wrapper cho Tesseract & PaddleOCR
+    service.py           # Điều phối pipeline, ghi log lịch sử
+```
+
+Tất cả dữ liệu được lưu dưới `python_service_data/run_<id>/` gồm `uploads/`, `intermediates/`, `outputs/`.
+
+## Chạy cục bộ (không Docker)
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r python_service/requirements.txt
+# Cài đặt hệ thống: tesseract-ocr, poppler-utils, libreoffice
+uvicorn python_service.main:app --reload --port 8000
+```
+
+Kiểm tra sức khỏe: `curl http://localhost:8000/health`
+
+Gửi tài liệu OCR:
+
+```bash
+curl -X POST "http://localhost:8000/ocr" \
+  -F "file=@/path/to/document.pdf" \
+  -F "mode=auto"
+```
+
+## Docker
+
+Dockerfile cài đặt đầy đủ thư viện hệ thống cần thiết: Tesseract OCR, Poppler (PDF → ảnh) và LibreOffice (DOCX → PDF).
+
+```bash
+cd python_service
+docker build -t python-ocr-service .
+docker run -it --rm -p 8000:8000 -v $(pwd)/data:/app/python_service_data python-ocr-service
+```
+
+## Biến môi trường
+
+| Biến | Mặc định | Mô tả |
+| --- | --- | --- |
+| `OCR_TESS_LANGUAGES` | `vie+eng` | Ngôn ngữ cho Tesseract |
+| `OCR_TESS_PSM` | `6` | Page segmentation mode |
+| `OCR_TESS_OEM` | `1` | OCR engine mode |
+| `OCR_PADDLE_LANG` | `en` | Ngôn ngữ của PaddleOCR |
+| `OCR_PADDLE_USE_GPU` | `false` | Bật GPU nếu có |
+| `OCR_DB_URL` | `sqlite:///python_service_data/ocr_history.sqlite` | Chuỗi kết nối SQLite |
+| `OCR_STORAGE_ROOT` | `python_service_data` | Thư mục lưu file |
+
+## Lưu ý chất lượng
+
+- Với tài liệu scan chất lượng thấp, nên dùng `mode=enhanced` để tận dụng PaddleOCR.
+- Có thể tinh chỉnh các bước tiền xử lý trong `preprocess.py` (tham số CLAHE, kernel sharpen, adaptive threshold).
+- Để cải thiện tốc độ, preload PaddleOCR (đã thực hiện khi lần đầu gọi).
+- Database lưu toàn bộ lịch sử kèm độ tin cậy trung bình theo từng engine cho việc benchmark nội bộ.
+

--- a/python_service/main.py
+++ b/python_service/main.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import logging
+from typing import Annotated
+
+from fastapi import FastAPI, File, Form, UploadFile
+from fastapi.responses import JSONResponse
+
+from ocr_service.service import SERVICE, OcrMode
+
+logging.basicConfig(level=logging.INFO)
+
+app = FastAPI(title="OCR Service", version="1.0.0")
+
+
+@app.post("/ocr")
+async def run_ocr(
+    file: UploadFile = File(...),
+    mode: Annotated[OcrMode, Form()] = "auto",
+) -> JSONResponse:
+    contents = await file.read()
+    result = SERVICE.process(contents, file.filename, mode=mode)
+    return JSONResponse(
+        {
+            "run_id": result.run_id,
+            "mode": result.mode,
+            "selected_engine": result.selected_engine,
+            "pages": [
+                {
+                    "page_number": res.page_number,
+                    "engine": res.engine,
+                    "confidence": res.confidence,
+                    "text": res.text,
+                }
+                for res in result.results
+            ],
+        }
+    )
+
+
+@app.get("/ocr/{run_id}")
+async def get_run(run_id: int) -> JSONResponse:
+    run = SERVICE.get_run(run_id)
+    return JSONResponse(run)
+
+
+@app.get("/ocr")
+async def list_runs(limit: int = 50) -> JSONResponse:
+    runs = SERVICE.list_runs(limit=limit)
+    return JSONResponse({"items": runs})
+
+
+@app.get("/health")
+async def health() -> JSONResponse:
+    return JSONResponse({"status": "ok"})

--- a/python_service/ocr_service/__init__.py
+++ b/python_service/ocr_service/__init__.py
@@ -1,0 +1,3 @@
+from .service import SERVICE, OcrService, OcrMode
+
+__all__ = ["SERVICE", "OcrService", "OcrMode"]

--- a/python_service/ocr_service/config.py
+++ b/python_service/ocr_service/config.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+
+@dataclass
+class TesseractConfig:
+    languages: str = os.getenv("OCR_TESS_LANGUAGES", "vie+eng")
+    psm: int = int(os.getenv("OCR_TESS_PSM", "6"))
+    oem: int = int(os.getenv("OCR_TESS_OEM", "1"))
+    config: str = os.getenv("OCR_TESS_CONFIG", "")
+
+
+@dataclass
+class PaddleConfig:
+    use_angle_cls: bool = os.getenv("OCR_PADDLE_USE_ANGLE", "true").lower() == "true"
+    lang: str = os.getenv("OCR_PADDLE_LANG", "en")
+    det_model_dir: Optional[str] = os.getenv("OCR_PADDLE_DET_MODEL")
+    rec_model_dir: Optional[str] = os.getenv("OCR_PADDLE_REC_MODEL")
+    use_gpu: bool = os.getenv("OCR_PADDLE_USE_GPU", "false").lower() == "true"
+    enable_mkldnn: bool = os.getenv("OCR_PADDLE_MKLDNN", "true").lower() == "true"
+    cpu_threads: int = int(os.getenv("OCR_PADDLE_CPU_THREADS", "4"))
+
+
+@dataclass
+class StorageConfig:
+    base_dir: Path = Path(os.getenv("OCR_STORAGE_ROOT", "python_service_data"))
+
+    @property
+    def uploads_dir(self) -> Path:
+        return self.base_dir / "uploads"
+
+    @property
+    def intermediates_dir(self) -> Path:
+        return self.base_dir / "intermediates"
+
+    @property
+    def outputs_dir(self) -> Path:
+        return self.base_dir / "outputs"
+
+
+@dataclass
+class DatabaseConfig:
+    url: str = os.getenv("OCR_DB_URL", "sqlite:///python_service_data/ocr_history.sqlite")
+
+
+@dataclass
+class AppConfig:
+    storage: StorageConfig = StorageConfig()
+    database: DatabaseConfig = DatabaseConfig()
+    tesseract: TesseractConfig = TesseractConfig()
+    paddle: PaddleConfig = PaddleConfig()
+    allowed_file_size_mb: int = int(os.getenv("OCR_MAX_FILE_MB", "25"))
+
+
+CONFIG = AppConfig()

--- a/python_service/ocr_service/database.py
+++ b/python_service/ocr_service/database.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import json
+from contextlib import contextmanager
+from datetime import datetime
+from typing import Generator, Optional
+
+from sqlalchemy import DateTime, Float, ForeignKey, Integer, String, Text, create_engine, event
+from sqlalchemy.engine import Engine
+from sqlalchemy.orm import DeclarativeBase, Mapped, Session, mapped_column, relationship, sessionmaker
+
+from .config import CONFIG
+
+
+def _enforce_foreign_keys(dbapi_connection, connection_record):
+    cursor = dbapi_connection.cursor()
+    cursor.execute("PRAGMA foreign_keys=ON")
+    cursor.close()
+
+
+class Base(DeclarativeBase):
+    pass
+
+
+class OcrRun(Base):
+    __tablename__ = "ocr_runs"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    original_file: Mapped[str] = mapped_column(String(1024), nullable=False)
+    original_mime: Mapped[Optional[str]] = mapped_column(String(128))
+    mode: Mapped[str] = mapped_column(String(32), nullable=False)
+    status: Mapped[str] = mapped_column(String(32), nullable=False, default="pending")
+    engine_used: Mapped[Optional[str]] = mapped_column(String(64))
+    extras_json: Mapped[Optional[str]] = mapped_column(Text)
+    error_message: Mapped[Optional[str]] = mapped_column(Text)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, nullable=False)
+    updated_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, nullable=False)
+
+    images: Mapped[list[OcrImage]] = relationship("OcrImage", back_populates="run", cascade="all, delete-orphan")
+    results: Mapped[list[OcrResult]] = relationship("OcrResult", back_populates="run", cascade="all, delete-orphan")
+
+    def set_extra(self, data: dict | None) -> None:
+        self.extras_json = json.dumps(data, ensure_ascii=False) if data else None
+
+    def get_extra(self) -> dict:
+        return json.loads(self.extras_json) if self.extras_json else {}
+
+
+class OcrImage(Base):
+    __tablename__ = "ocr_images"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    run_id: Mapped[int] = mapped_column(ForeignKey("ocr_runs.id", ondelete="CASCADE"), nullable=False)
+    role: Mapped[str] = mapped_column(String(64), nullable=False)
+    path: Mapped[str] = mapped_column(String(1024), nullable=False)
+    page_number: Mapped[Optional[int]] = mapped_column(Integer)
+    step: Mapped[Optional[str]] = mapped_column(String(128))
+    metadata_json: Mapped[Optional[str]] = mapped_column(Text)
+
+    run: Mapped[OcrRun] = relationship("OcrRun", back_populates="images")
+
+    def set_metadata(self, data: dict | None) -> None:
+        self.metadata_json = json.dumps(data, ensure_ascii=False) if data else None
+
+    def get_metadata(self) -> dict:
+        return json.loads(self.metadata_json) if self.metadata_json else {}
+
+
+class OcrResult(Base):
+    __tablename__ = "ocr_results"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    run_id: Mapped[int] = mapped_column(ForeignKey("ocr_runs.id", ondelete="CASCADE"), nullable=False)
+    engine: Mapped[str] = mapped_column(String(64), nullable=False)
+    mode: Mapped[str] = mapped_column(String(32), nullable=False)
+    page_number: Mapped[Optional[int]] = mapped_column(Integer)
+    text: Mapped[str] = mapped_column(Text, nullable=False)
+    confidence: Mapped[Optional[float]] = mapped_column(Float)
+    extra_json: Mapped[Optional[str]] = mapped_column(Text)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, nullable=False)
+
+    run: Mapped[OcrRun] = relationship("OcrRun", back_populates="results")
+
+    def set_extra(self, data: dict | None) -> None:
+        self.extra_json = json.dumps(data, ensure_ascii=False) if data else None
+
+    def get_extra(self) -> dict:
+        return json.loads(self.extra_json) if self.extra_json else {}
+
+
+engine: Engine = create_engine(CONFIG.database.url, future=True, echo=False)
+
+
+@event.listens_for(engine, "connect")
+def _on_connect(dbapi_connection, connection_record):
+    _enforce_foreign_keys(dbapi_connection, connection_record)
+
+
+SessionLocal = sessionmaker(bind=engine, autoflush=False, expire_on_commit=False)
+
+
+def init_db() -> None:
+    Base.metadata.create_all(bind=engine)
+
+
+@contextmanager
+def session_scope() -> Generator[Session, None, None]:
+    session = SessionLocal()
+    try:
+        yield session
+        session.commit()
+    except Exception:
+        session.rollback()
+        raise
+    finally:
+        session.close()

--- a/python_service/ocr_service/document_processor.py
+++ b/python_service/ocr_service/document_processor.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import mimetypes
+import shutil
+import subprocess
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+from pdf2image import convert_from_path
+
+from .preprocess import PREPROCESSOR, PreprocessResult
+
+
+SUPPORTED_IMAGE_TYPES = {
+    "image/png",
+    "image/jpeg",
+    "image/jpg",
+    "image/tiff",
+    "image/bmp",
+    "image/webp",
+}
+
+
+@dataclass
+class PreparedDocument:
+    original_path: Path
+    mime_type: Optional[str]
+    page_images: list[Path]
+    preprocessed: list[PreprocessResult]
+    converted_files: list[tuple[str, Path]]
+
+
+class DocumentProcessor:
+    def __init__(self) -> None:
+        self.preprocessor = PREPROCESSOR
+
+    def detect_mime(self, file_path: Path) -> Optional[str]:
+        mime, _ = mimetypes.guess_type(file_path)
+        return mime
+
+    def _convert_docx_to_pdf(self, docx_path: Path) -> Path:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpdir_path = Path(tmpdir)
+            result = subprocess.run(
+                [
+                    "libreoffice",
+                    "--headless",
+                    "--convert-to",
+                    "pdf",
+                    str(docx_path),
+                    "--outdir",
+                    str(tmpdir_path),
+                ],
+                capture_output=True,
+                check=False,
+            )
+            if result.returncode != 0:
+                raise RuntimeError(
+                    f"Failed to convert DOCX to PDF: {result.stderr.decode('utf-8', errors='ignore')}"
+                )
+            pdf_files = list(tmpdir_path.glob("*.pdf"))
+            if not pdf_files:
+                raise RuntimeError("DOCX conversion did not produce a PDF")
+            target_pdf = docx_path.with_suffix(".pdf")
+            shutil.move(str(pdf_files[0]), target_pdf)
+            return target_pdf
+
+    def _convert_pdf_to_images(self, pdf_path: Path, output_dir: Path) -> list[Path]:
+        pages = convert_from_path(str(pdf_path), dpi=300)
+        image_paths: list[Path] = []
+        for idx, page in enumerate(pages, start=1):
+            image_path = self.preprocessor.save_pdf_page(page, output_dir, f"page_{idx:03d}")
+            image_paths.append(image_path)
+        return image_paths
+
+    def _copy_image(self, image_path: Path, output_dir: Path) -> Path:
+        target = output_dir / image_path.name
+        shutil.copy(image_path, target)
+        return target
+
+    def prepare(self, file_path: Path, run_dirs: dict[str, Path]) -> PreparedDocument:
+        mime = self.detect_mime(file_path)
+        page_images: list[Path] = []
+        converted_files: list[tuple[str, Path]] = []
+
+        if file_path.suffix.lower() in {".doc", ".docx"}:
+            pdf_path = self._convert_docx_to_pdf(file_path)
+            page_images = self._convert_pdf_to_images(pdf_path, run_dirs["uploads"])
+            converted_files.append(("docx_to_pdf", pdf_path))
+        elif file_path.suffix.lower() in {".pdf"}:
+            page_images = self._convert_pdf_to_images(file_path, run_dirs["uploads"])
+        elif mime in SUPPORTED_IMAGE_TYPES:
+            copied = self._copy_image(file_path, run_dirs["uploads"])
+            page_images = [copied]
+        else:
+            raise ValueError(f"Unsupported file type: {file_path.suffix}")
+
+        preprocessed: list[PreprocessResult] = []
+        for idx, image_path in enumerate(page_images, start=1):
+            result = self.preprocessor.enhance(image_path, run_dirs["intermediates"], f"page_{idx:03d}")
+            preprocessed.append(result)
+
+        return PreparedDocument(
+            original_path=file_path,
+            mime_type=mime,
+            page_images=page_images,
+            preprocessed=preprocessed,
+            converted_files=converted_files,
+        )
+
+
+DOCUMENT_PROCESSOR = DocumentProcessor()

--- a/python_service/ocr_service/engines.py
+++ b/python_service/ocr_service/engines.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+import numpy as np
+import pytesseract
+from paddleocr import PaddleOCR
+from pytesseract import Output
+
+from .config import CONFIG
+
+LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class OcrEngineResult:
+    text: str
+    confidence: Optional[float]
+    engine: str
+    page_number: Optional[int]
+    extra: dict
+
+
+class TesseractEngine:
+    def __init__(self) -> None:
+        self.config = CONFIG.tesseract
+
+    def run(self, image_path: Path, page_number: Optional[int] = None) -> OcrEngineResult:
+        tess_config = self.config.config or ""
+        custom_config = f"--psm {self.config.psm} --oem {self.config.oem} {tess_config}".strip()
+        data = pytesseract.image_to_data(
+            str(image_path),
+            lang=self.config.languages,
+            output_type=Output.DICT,
+            config=custom_config,
+        )
+        text = pytesseract.image_to_string(
+            str(image_path), lang=self.config.languages, config=custom_config
+        )
+        confidences = [int(conf) for conf in data.get("conf", []) if conf and conf != "-1"]
+        avg_conf = float(np.mean(confidences)) if confidences else None
+        return OcrEngineResult(
+            text=text,
+            confidence=avg_conf,
+            engine="tesseract",
+            page_number=page_number,
+            extra={"word_data": data},
+        )
+
+
+class PaddleEngine:
+    def __init__(self) -> None:
+        self.config = CONFIG.paddle
+        self._ocr: Optional[PaddleOCR] = None
+
+    def _load(self) -> PaddleOCR:
+        if self._ocr is None:
+            LOGGER.info("Loading PaddleOCR (lang=%s, gpu=%s)", self.config.lang, self.config.use_gpu)
+            self._ocr = PaddleOCR(
+                use_angle_cls=self.config.use_angle_cls,
+                lang=self.config.lang,
+                use_gpu=self.config.use_gpu,
+                enable_mkldnn=self.config.enable_mkldnn,
+                det_model_dir=self.config.det_model_dir,
+                rec_model_dir=self.config.rec_model_dir,
+                cpu_threads=self.config.cpu_threads,
+            )
+        return self._ocr
+
+    def run(self, image_path: Path, page_number: Optional[int] = None) -> OcrEngineResult:
+        ocr = self._load()
+        result = ocr.ocr(str(image_path), det=True, rec=True, cls=True)
+        lines = []
+        confidences = []
+        for line in result:
+            for _, (text, conf) in line:
+                lines.append(text)
+                confidences.append(conf)
+        text = "\n".join(lines)
+        avg_conf = float(np.mean(confidences)) if confidences else None
+        return OcrEngineResult(
+            text=text,
+            confidence=avg_conf,
+            engine="paddleocr",
+            page_number=page_number,
+            extra={"raw": result},
+        )
+
+
+TESSERACT_ENGINE = TesseractEngine()
+PADDLE_ENGINE = PaddleEngine()

--- a/python_service/ocr_service/preprocess.py
+++ b/python_service/ocr_service/preprocess.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+import cv2
+import numpy as np
+from PIL import Image
+
+
+@dataclass
+class PreprocessResult:
+    original_path: Path
+    processed_path: Path
+    steps: list[str]
+
+
+class ImagePreprocessor:
+    """Apply a sequence of preprocessing steps tuned for OCR."""
+
+    def enhance(self, image_path: Path, output_dir: Path, prefix: str) -> PreprocessResult:
+        image = cv2.imread(str(image_path), cv2.IMREAD_COLOR)
+        if image is None:
+            raise ValueError(f"Cannot read image: {image_path}")
+
+        steps: list[str] = []
+
+        gray = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
+        steps.append("grayscale")
+
+        denoised = cv2.fastNlMeansDenoising(gray, h=30, templateWindowSize=7, searchWindowSize=21)
+        steps.append("denoise")
+
+        clahe = cv2.createCLAHE(clipLimit=2.0, tileGridSize=(8, 8))
+        clahe_img = clahe.apply(denoised)
+        steps.append("clahe")
+
+        blurred = cv2.GaussianBlur(clahe_img, (3, 3), 0)
+        sharpen_kernel = np.array([[0, -1, 0], [-1, 5, -1], [0, -1, 0]])
+        sharpened = cv2.filter2D(blurred, -1, sharpen_kernel)
+        steps.append("sharpen")
+
+        thresh = cv2.adaptiveThreshold(
+            sharpened,
+            255,
+            cv2.ADAPTIVE_THRESH_GAUSSIAN_C,
+            cv2.THRESH_BINARY,
+            31,
+            5,
+        )
+        steps.append("adaptive_threshold")
+
+        processed_path = output_dir / f"{prefix}_processed.png"
+        cv2.imwrite(str(processed_path), thresh)
+
+        return PreprocessResult(original_path=image_path, processed_path=processed_path, steps=steps)
+
+    def save_pdf_page(self, pil_image: Image.Image, output_dir: Path, prefix: str) -> Path:
+        path = output_dir / f"{prefix}.png"
+        pil_image.save(path)
+        return path
+
+
+PREPROCESSOR = ImagePreprocessor()

--- a/python_service/ocr_service/service.py
+++ b/python_service/ocr_service/service.py
@@ -1,0 +1,253 @@
+from __future__ import annotations
+
+import logging
+import mimetypes
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Literal, Optional
+
+from fastapi import HTTPException
+
+from .config import CONFIG
+from .database import OcrImage, OcrResult, OcrRun, init_db, session_scope
+from .document_processor import DOCUMENT_PROCESSOR
+from .engines import OcrEngineResult, PADDLE_ENGINE, TESSERACT_ENGINE
+from .storage import STORAGE
+
+LOGGER = logging.getLogger(__name__)
+
+OcrMode = Literal["auto", "fast", "enhanced"]
+
+
+@dataclass
+class ServiceResult:
+    run_id: int
+    mode: str
+    results: list[OcrEngineResult]
+    selected_engine: str
+
+
+class OcrService:
+    def __init__(self) -> None:
+        init_db()
+
+    def _update_run(self, run_id: int, **kwargs) -> None:
+        with session_scope() as session:
+            run = session.get(OcrRun, run_id)
+            if not run:
+                raise RuntimeError(f"Run {run_id} not found")
+            for key, value in kwargs.items():
+                setattr(run, key, value)
+            run.updated_at = datetime.utcnow()
+
+    def _record_images(self, run_id: int, prepared) -> None:
+        with session_scope() as session:
+            run = session.get(OcrRun, run_id)
+            if not run:
+                raise RuntimeError(f"Run {run_id} not found")
+            original = OcrImage(
+                run_id=run_id,
+                role="original",
+                path=str(prepared.original_path),
+                page_number=None,
+                step="upload",
+            )
+            session.add(original)
+            for conversion, path in prepared.converted_files:
+                image = OcrImage(
+                    run_id=run_id,
+                    role="converted",
+                    path=str(path),
+                    page_number=None,
+                    step=conversion,
+                )
+                session.add(image)
+            for idx, page in enumerate(prepared.page_images, start=1):
+                session.add(
+                    OcrImage(
+                        run_id=run_id,
+                        role="page",
+                        path=str(page),
+                        page_number=idx,
+                        step="page_image",
+                    )
+                )
+            for idx, pre in enumerate(prepared.preprocessed, start=1):
+                img = OcrImage(
+                    run_id=run_id,
+                    role="preprocessed",
+                    path=str(pre.processed_path),
+                    page_number=idx,
+                    step="preprocess",
+                )
+                img.set_metadata({"steps": pre.steps})
+                session.add(img)
+
+    def _persist_results(
+        self,
+        run_id: int,
+        mode: OcrMode,
+        results: list[OcrEngineResult],
+        selected_engine: str,
+    ) -> None:
+        with session_scope() as session:
+            for result in results:
+                entity = OcrResult(
+                    run_id=run_id,
+                    engine=result.engine,
+                    mode=mode,
+                    page_number=result.page_number,
+                    text=result.text,
+                    confidence=result.confidence,
+                )
+                entity.set_extra(result.extra)
+                session.add(entity)
+            run = session.get(OcrRun, run_id)
+            if not run:
+                raise RuntimeError(f"Run {run_id} not found while persisting results")
+            run.status = "completed"
+            run.engine_used = selected_engine
+            run.set_extra({"selected_engine": selected_engine})
+            run.updated_at = datetime.utcnow()
+
+    def process(self, file_bytes: bytes, filename: str, mode: OcrMode = "auto") -> ServiceResult:
+        if len(file_bytes) == 0:
+            raise HTTPException(status_code=400, detail="Empty file provided")
+        max_bytes = CONFIG.allowed_file_size_mb * 1024 * 1024
+        if len(file_bytes) > max_bytes:
+            raise HTTPException(
+                status_code=413,
+                detail=f"File too large. Max size is {CONFIG.allowed_file_size_mb} MB",
+            )
+
+        mime, _ = mimetypes.guess_type(filename)
+        with session_scope() as session:
+            temp_run = OcrRun(
+                original_file=filename,
+                original_mime=mime,
+                mode=mode,
+                status="initializing",
+            )
+            session.add(temp_run)
+            session.flush()
+            run_id = temp_run.id
+
+        run_dirs = STORAGE.prepare_run_directory(run_id)
+        saved_path = STORAGE.save_upload(file_bytes, filename, run_dirs["uploads"])
+        self._update_run(
+            run_id,
+            original_file=str(saved_path),
+            original_mime=mime,
+            status="processing",
+        )
+
+        try:
+            prepared = DOCUMENT_PROCESSOR.prepare(saved_path, run_dirs)
+            self._record_images(run_id, prepared)
+
+            all_results: list[OcrEngineResult] = []
+            for idx, prep in enumerate(prepared.preprocessed, start=1):
+                if mode in ("fast", "auto"):
+                    tess_result = TESSERACT_ENGINE.run(prep.processed_path, page_number=idx)
+                    all_results.append(tess_result)
+                if mode in ("enhanced", "auto"):
+                    paddle_result = PADDLE_ENGINE.run(prep.processed_path, page_number=idx)
+                    all_results.append(paddle_result)
+
+            selected_engine = self._select_engine(all_results, mode)
+            self._persist_results(run_id, mode, all_results, selected_engine)
+
+            selected_results = [res for res in all_results if res.engine == selected_engine]
+            return ServiceResult(run_id=run_id, mode=mode, results=selected_results, selected_engine=selected_engine)
+        except Exception as exc:  # noqa: BLE001
+            LOGGER.exception("OCR processing failed")
+            self._update_run(run_id, status="failed", error_message=str(exc))
+            raise HTTPException(status_code=500, detail=f"OCR processing failed: {exc}") from exc
+
+    def _select_engine(self, results: list[OcrEngineResult], mode: OcrMode) -> str:
+        if mode == "fast":
+            return "tesseract"
+        if mode == "enhanced":
+            return "paddleocr"
+
+        # Auto mode: choose engine with highest average confidence
+        engine_conf: dict[str, list[float]] = {}
+        for result in results:
+            if result.confidence is not None:
+                engine_conf.setdefault(result.engine, []).append(result.confidence)
+
+        if not engine_conf:
+            return "tesseract"
+
+        avg_conf = {
+            engine: sum(values) / len(values)
+            for engine, values in engine_conf.items()
+            if values
+        }
+        if not avg_conf:
+            return "tesseract"
+        return max(avg_conf, key=avg_conf.get)
+
+    def get_run(self, run_id: int) -> dict:
+        with session_scope() as session:
+            run = session.get(OcrRun, run_id)
+            if not run:
+                raise HTTPException(status_code=404, detail="Run not found")
+            return {
+                "id": run.id,
+                "mode": run.mode,
+                "status": run.status,
+                "engine_used": run.engine_used,
+                "original_file": run.original_file,
+                "created_at": run.created_at.isoformat(),
+                "updated_at": run.updated_at.isoformat(),
+                "error_message": run.error_message,
+                "extras": run.get_extra(),
+                "results": [
+                    {
+                        "id": result.id,
+                        "engine": result.engine,
+                        "page_number": result.page_number,
+                        "confidence": result.confidence,
+                        "text": result.text,
+                        "extra": result.get_extra(),
+                    }
+                    for result in run.results
+                ],
+                "images": [
+                    {
+                        "id": image.id,
+                        "role": image.role,
+                        "path": image.path,
+                        "page_number": image.page_number,
+                        "step": image.step,
+                        "metadata": image.get_metadata(),
+                    }
+                    for image in run.images
+                ],
+            }
+
+    def list_runs(self, limit: int = 50) -> list[dict]:
+        with session_scope() as session:
+            runs = (
+                session.query(OcrRun)
+                .order_by(OcrRun.created_at.desc())
+                .limit(limit)
+                .all()
+            )
+            return [
+                {
+                    "id": run.id,
+                    "mode": run.mode,
+                    "status": run.status,
+                    "engine_used": run.engine_used,
+                    "created_at": run.created_at.isoformat(),
+                    "updated_at": run.updated_at.isoformat(),
+                    "original_file": run.original_file,
+                }
+                for run in runs
+            ]
+
+
+SERVICE = OcrService()

--- a/python_service/ocr_service/storage.py
+++ b/python_service/ocr_service/storage.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import shutil
+from datetime import datetime
+from pathlib import Path
+from typing import Iterable
+
+from .config import CONFIG
+
+
+class StorageManager:
+    def __init__(self) -> None:
+        self.config = CONFIG.storage
+        self._ensure_directories()
+
+    def _ensure_directories(self) -> None:
+        for directory in (
+            self.config.base_dir,
+            self.config.uploads_dir,
+            self.config.intermediates_dir,
+            self.config.outputs_dir,
+        ):
+            directory.mkdir(parents=True, exist_ok=True)
+
+    def prepare_run_directory(self, run_id: int) -> dict[str, Path]:
+        run_root = self.config.base_dir / f"run_{run_id:08d}"
+        uploads = run_root / "uploads"
+        intermediates = run_root / "intermediates"
+        outputs = run_root / "outputs"
+        for directory in (run_root, uploads, intermediates, outputs):
+            directory.mkdir(parents=True, exist_ok=True)
+        return {
+            "root": run_root,
+            "uploads": uploads,
+            "intermediates": intermediates,
+            "outputs": outputs,
+        }
+
+    def save_upload(self, file_bytes: bytes, original_name: str, run_dir: Path) -> Path:
+        timestamp = datetime.utcnow().strftime("%Y%m%dT%H%M%S%f")
+        sanitized_name = original_name.replace("/", "_")
+        target = run_dir / f"{timestamp}_{sanitized_name}"
+        with open(target, "wb") as f:
+            f.write(file_bytes)
+        return target
+
+    def copy_files(self, files: Iterable[Path], target_dir: Path) -> list[Path]:
+        copied: list[Path] = []
+        for file_path in files:
+            destination = target_dir / file_path.name
+            shutil.copy(file_path, destination)
+            copied.append(destination)
+        return copied
+
+
+STORAGE = StorageManager()

--- a/python_service/requirements.txt
+++ b/python_service/requirements.txt
@@ -1,0 +1,11 @@
+fastapi==0.110.0
+uvicorn[standard]==0.29.0
+sqlalchemy==2.0.29
+pillow==10.3.0
+pdf2image==1.17.0
+opencv-python-headless==4.9.0.80
+numpy==1.26.4
+pytesseract==0.3.10
+paddleocr==2.7.0.3
+paddlepaddle==2.6.1
+python-multipart==0.0.9


### PR DESCRIPTION
## Summary
- add a Python-based OCR service with FastAPI exposing fast, enhanced, and auto modes for Tesseract and PaddleOCR engines
- persist OCR history, intermediate assets, and engine confidences in SQLite with structured storage helpers
- include preprocessing, document conversion utilities, Dockerfile, and documentation for running the service

## Testing
- python -m compileall python_service


------
https://chatgpt.com/codex/tasks/task_e_68db8ff9b1a0832894d0a801cf62c3bd